### PR TITLE
patch: add dataloader to the schema context

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -266,12 +266,14 @@ pub(super) fn build_schema(
     database: QuasarDatabase,
 ) -> ServiceSchema {
     let database = database.as_inner().clone();
+    let quasar_db = QuasarDataLoader::new(database.clone());
     let mut schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
         .data(DataLoader::new(
-            QuasarDataLoader::new(database.clone()),
+            quasar_db.clone(),
             tokio::spawn,
         ))
-        .data(database);
+        .data(database)
+        .data(quasar_db);
 
     if cfg!(debug_assertions) {
         info!("Debugging enabled, no limits on query");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -268,10 +268,7 @@ pub(super) fn build_schema(
     let database = database.as_inner().clone();
     let quasar_db = QuasarDataLoader::new(database.clone());
     let mut schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
-        .data(DataLoader::new(
-            quasar_db.clone(),
-            tokio::spawn,
-        ))
+        .data(DataLoader::new(quasar_db.clone(), tokio::spawn))
         .data(database)
         .data(quasar_db);
 


### PR DESCRIPTION
This is a patch, we need to decide which is the core database type.